### PR TITLE
feat: enable encrypted Hetzner CSI storage classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ Here is a table with more example calculations:
 
 #### Hetzner Cloud CSI
 
-The Hetzner Cloud Container Storage Interface (CSI) driver can be flexibly configured through the `hcloud_csi_storage_classes` variable. You can define multiple storage classes for your cluster:
+The Hetzner Cloud Container Storage Interface (CSI) driver is enabled by default with an encrypted ext4 StorageClass. You can add further classes through the `hcloud_csi_storage_classes` variable:
 
 * **name:** The name of the StorageClass (string, required).
 * **encrypted:** Enable LUKS encryption for volumes (bool, required).
@@ -604,13 +604,18 @@ The Hetzner Cloud Container Storage Interface (CSI) driver can be flexibly confi
 ```hcl
 hcloud_csi_storage_classes = [
   {
-    name                = "hcloud-volumes"
-    encrypted           = false
+    name                = "hcloud-volumes-encrypted"
+    encrypted           = true
     defaultStorageClass = true
+    reclaimPolicy       = "Retain"
+    extraParameters     = {
+      "csi.storage.k8s.io/fstype" = "ext4"
+    }
   },
   {
     name                = "hcloud-volumes-encrypted-xfs"
     encrypted           = true
+    defaultStorageClass = false
     reclaimPolicy       = "Retain"
     extraParameters     = {
       "csi.storage.k8s.io/fstype" = "xfs"
@@ -620,10 +625,12 @@ hcloud_csi_storage_classes = [
 ]
 ```
 
+Hetzner CSI does not support volume snapshots and only provides `ReadWriteOnce` volumes. Use application-level or file-level backups, and plan for a separate NFS or Ceph solution if `ReadWriteMany` access is required.
+
 **Other settings:**
 
 * **hcloud\_csi\_encryption\_passphrase:**
-  Optionally provide a custom encryption passphrase for LUKS-encrypted storage classes.
+  Provide the LUKS passphrase used to unlock encrypted volumes.
 
   ```hcl
   hcloud_csi_encryption_passphrase = "<secret-passphrase>"
@@ -637,8 +644,7 @@ For more details, see the [HCloud CSI Driver documentation](https://github.com/h
 
 #### Longhorn
 
-Longhorn is a lightweight, reliable, and easy-to-use distributed block storage system for Kubernetes.
-It is fully independent from the Hetzner Cloud CSI driver.
+Longhorn is a lightweight, reliable, and easy-to-use distributed block storage system for Kubernetes. It is disabled by default and fully independent from the Hetzner Cloud CSI driver.
 
 You can enable Longhorn and configure it as the default StorageClass for your cluster via module variables:
 

--- a/opentofu/kubernetes.tofu
+++ b/opentofu/kubernetes.tofu
@@ -21,36 +21,62 @@ module "kubernetes" {
 
   cert_manager_enabled           = true
   ingress_nginx_enabled          = false
-  longhorn_enabled               = true
-  longhorn_default_storage_class = true
+  longhorn_enabled               = false
+  longhorn_default_storage_class = false
 
-  firewall_use_current_ipv4 = false
-  firewall_use_current_ipv6 = false
-  firewall_api_source = var.firewall_api_source
+  hcloud_csi_enabled = true
+
+  hcloud_csi_storage_classes = [
+    {
+      name                = "hcloud-volumes-encrypted"
+      encrypted           = true
+      defaultStorageClass = true
+      reclaimPolicy       = "Retain"
+      extraParameters = {
+        "csi.storage.k8s.io/fstype" = "ext4"
+      }
+    },
+    {
+      name                = "hcloud-volumes-encrypted-xfs"
+      encrypted           = true
+      defaultStorageClass = false
+      reclaimPolicy       = "Retain"
+      extraParameters = {
+        "csi.storage.k8s.io/fstype" = "xfs"
+        "fsFormatOption"            = "-i nrext64=1"
+      }
+    }
+  ]
+
+  hcloud_csi_encryption_passphrase = var.hcloud_csi_encryption_passphrase
+
+  firewall_use_current_ipv4      = false
+  firewall_use_current_ipv6      = false
+  firewall_api_source            = var.firewall_api_source
   kube_api_load_balancer_enabled = true
   #kube_api_hostname              = "kube-api.goingdark.social"
-# firewall_extra_rules = [
-#   {
-#     description = "Custom UDP Rule"
-#     direction   = "in"
-#     source_ips  = ["0.0.0.0/0", "::/0"]
-#     protocol    = "udp"
-#     port        = "12345"
-#   },
-#   {
-#     description = "Custom TCP Rule"
-#     direction   = "in"
-#     source_ips  = ["1.2.3.4", "1:2:3:4::"]
-#     protocol    = "tcp"
-#     port        = "8080-9000"
-#   },
-#   {
-#     description = "Allow ICMP"
-#     direction   = "in"
-#     source_ips  = ["0.0.0.0/0", "::/0"]
-#     protocol    = "icmp"
-#   }
-# ]
+  # firewall_extra_rules = [
+  #   {
+  #     description = "Custom UDP Rule"
+  #     direction   = "in"
+  #     source_ips  = ["0.0.0.0/0", "::/0"]
+  #     protocol    = "udp"
+  #     port        = "12345"
+  #   },
+  #   {
+  #     description = "Custom TCP Rule"
+  #     direction   = "in"
+  #     source_ips  = ["1.2.3.4", "1:2:3:4::"]
+  #     protocol    = "tcp"
+  #     port        = "8080-9000"
+  #   },
+  #   {
+  #     description = "Allow ICMP"
+  #     direction   = "in"
+  #     source_ips  = ["0.0.0.0/0", "::/0"]
+  #     protocol    = "icmp"
+  #   }
+  # ]
 
   # Enable public IPv4 for both internet access and cluster bootstrap
   talos_public_ipv4_enabled = true
@@ -77,10 +103,10 @@ module "kubernetes" {
   #   }
   # }
 
-   cilium_encryption_enabled = true
-   cilium_encryption_type    = "wireguard"
+  cilium_encryption_enabled = true
+  cilium_encryption_type    = "wireguard"
 
-    talos_extra_remote_manifests = [
+  talos_extra_remote_manifests = [
     "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml",
     "https://raw.githubusercontent.com/external-secrets/external-secrets/v0.19.2/deploy/crds/bundle.yaml",
   ]
@@ -153,4 +179,10 @@ variable "bitwarden_token" {
   type        = string
   sensitive   = true
   description = "Bitwarden access token for External-Secrets"
+}
+
+variable "hcloud_csi_encryption_passphrase" {
+  type        = string
+  sensitive   = true
+  description = "Encryption passphrase for Hetzner CSI (LUKS)."
 }


### PR DESCRIPTION
## Summary
- disable Longhorn and enable Hetzner CSI
- default to encrypted ext4 storage class with optional encrypted xfs
- document CSI limitations and required passphrase

## Testing
- `tofu init -upgrade` *(fails: Error accessing remote module registry)*
- `tofu plan` *(fails: Required plugins are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68aaeb2c45588322938dbf66d495d290