### PR TITLE
feat(mastodon): expose metrics and autoscale web pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ Once deployed, the cluster hosts:
 
 All applications are managed through ArgoCD and deploy automatically when changes are pushed to the `kubernetes/` directory.
 
+## Mastodon Web Metrics and Autoscaling
+
+- The `mastodon-web` service now exposes port 9394 so each pod's `/metrics` endpoint is reachable inside the cluster.
+- VictoriaMetrics scrapes that endpoint through a `VMServiceScrape` and a Prometheus adapter publishes custom metrics for queue latency, backlog, and request rate.
+- The horizontal pod autoscaler targets a 50 ms p95 queue duration, caps backlog at 20 pending requests, and still watches CPU at 70% so we have a safety net.
+- Scale ups react inside 30 seconds and can add up to three pods at once, while scale downs wait three minutes before stepping back to avoid flapping.
+
 ## Tech Stack
 
 **Infrastructure**: Hetzner Cloud, Talos Linux, OpenTofu

--- a/kubernetes/apps/base-system/victoriametrics/helm-values.yaml
+++ b/kubernetes/apps/base-system/victoriametrics/helm-values.yaml
@@ -127,6 +127,47 @@ vmagent:
       limits:
         memory: 500Mi
 
+prometheus-adapter:
+  enabled: true
+  prometheus:
+    url: http://vm-victoria-metrics-k8s-stack.victoriametrics.svc.cluster.local
+    port: 8428
+  rules:
+    external:
+      - seriesQuery: 'ruby_http_request_queue_duration_seconds_bucket{job="mastodon-web"}'
+        name:
+          matches: "ruby_http_request_queue_duration_seconds_bucket"
+          as: "ruby_http_request_queue_duration_seconds_p95"
+        metricsQuery: 'histogram_quantile(0.95, rate(<<.Series>>[2m]))'
+        resources:
+          overrides:
+            namespace: {resource: "namespace"}
+            pod: {resource: "pod"}
+      - seriesQuery: 'ruby_puma_request_backlog{job="mastodon-web"}'
+        name:
+          matches: "ruby_puma_request_backlog"
+          as: "ruby_puma_request_backlog_max"
+        metricsQuery: 'max(<<.Series>>)'
+        resources:
+          overrides:
+            namespace: {resource: "namespace"}
+            pod: {resource: "pod"}
+      - seriesQuery: 'ruby_http_requests_total{job="mastodon-web"}'
+        name:
+          matches: "ruby_http_requests_total"
+          as: "ruby_http_requests_per_second"
+        metricsQuery: 'rate(<<.Series>>[2m])'
+        resources:
+          overrides:
+            namespace: {resource: "namespace"}
+            pod: {resource: "pod"}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+
 kubeEtcd:
   endpoints: *api-endpoints
   service:

--- a/kubernetes/apps/platform/mastodon/resources/autoscaling/web-hpa.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/autoscaling/web-hpa.yaml
@@ -3,40 +3,63 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: mastodon-web-hpa
   namespace: mastodon
+  annotations:
+    autoscaling.alpha.kubernetes.io/conditions: |
+      Primary metric: ruby_http_request_queue_duration_seconds_p95 scales on queue latency
+      Target: 50ms p95 latency for the web pods
+      Fallback: CPU utilization at 70 percent as a safety net
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: mastodon-web
   minReplicas: 2
-  maxReplicas: 4
+  maxReplicas: 10
   metrics:
+    - type: External
+      external:
+        metric:
+          name: ruby_http_request_queue_duration_seconds_p95
+          selector:
+            matchLabels:
+              job: mastodon-web
+        target:
+          type: Value
+          value: "50m"
+    - type: External
+      external:
+        metric:
+          name: ruby_puma_request_backlog_max
+          selector:
+            matchLabels:
+              job: mastodon-web
+        target:
+          type: Value
+          value: "20"
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
           averageUtilization: 70
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 90
   behavior:
     scaleUp:
-      stabilizationWindowSeconds: 60    # reduced from 300s for faster response
+      stabilizationWindowSeconds: 30
       policies:
         - type: Pods
-          value: 2                      # allow 2 pods per period
-          periodSeconds: 15             # every 15s instead of 120s
+          value: 3
+          periodSeconds: 30
         - type: Percent
-          value: 50                     # or 50% increase per period
-          periodSeconds: 15
-      selectPolicy: Max                 # choose the more aggressive policy
+          value: 100
+          periodSeconds: 30
+      selectPolicy: Max
     scaleDown:
-      stabilizationWindowSeconds: 900   # keep conservative 15 min before scaling down
+      stabilizationWindowSeconds: 180
       policies:
         - type: Pods
           value: 1
-          periodSeconds: 300
+          periodSeconds: 60
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+      selectPolicy: Min

--- a/kubernetes/apps/platform/mastodon/resources/kustomization.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - autoscaling
 - disruption
 - jobs
+- monitoring
 - networking
 - priorityclasses.yaml
 - secrets

--- a/kubernetes/apps/platform/mastodon/resources/monitoring/kustomization.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/monitoring/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - web-vmservicescrape.yaml

--- a/kubernetes/apps/platform/mastodon/resources/monitoring/web-vmservicescrape.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/monitoring/web-vmservicescrape.yaml
@@ -1,0 +1,26 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: mastodon-web-metrics
+  namespace: mastodon
+  labels:
+    app: mastodon-web
+spec:
+  selector:
+    matchLabels:
+      app: mastodon-web
+      component: web
+  endpoints:
+    - port: metrics
+      interval: 30s
+      path: /metrics
+      honorLabels: true
+      relabelConfigs:
+        - sourceLabels: [__meta_kubernetes_service_name]
+          targetLabel: service
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - targetLabel: job
+          replacement: mastodon-web

--- a/kubernetes/apps/platform/mastodon/resources/services/web-svc.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/services/web-svc.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: mastodon-web
   namespace: mastodon
+  labels:
+    app: mastodon-web
+    component: web
 spec:
   type: ClusterIP
   selector:
@@ -11,3 +14,6 @@ spec:
     - name: http
       port: 3000
       targetPort: 3000
+    - name: metrics
+      port: 9394
+      targetPort: 9394


### PR DESCRIPTION
## Summary
- expose the Mastodon web service metrics port and wire a VMServiceScrape so VictoriaMetrics can collect pod data
- configure the VictoriaMetrics chart to enable the Prometheus adapter and publish Mastodon web latency, backlog, and request metrics
- replace the web horizontal pod autoscaler with queue-latency driven scaling and document the new behavior in the README

## Testing
- `cd kubernetes/apps/platform/mastodon && kustomize build .`
- `cd kubernetes/apps/base-system/victoriametrics && kustomize build --enable-helm .` *(fails: upstream chart repos return 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc25d45d883229e3708daa38d3f69