### PR TITLE
feat: add CloudNativePG replica migration resources

### DIFF
--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
 - project.yaml
 - postgresql
+- cloudnative-pg

--- a/kubernetes/apps/platform/mastodon/MIGRATION.md
+++ b/kubernetes/apps/platform/mastodon/MIGRATION.md
@@ -1,0 +1,106 @@
+# CNPG Migration - Manual Steps
+
+## Pre-Cutover Checklist (Run by Operator)
+
+1. **Extract Zalando standby password:**
+   ```bash
+   kubectl get secret mastodon-postgresql.standby.credentials -n mastodon \
+     -o jsonpath='{.data.password}' | base64 -d
+   ```
+   Update the `zalando-standby-credentials` secret in `database-cnpg.yaml` with this value.
+
+2. **Verify CNPG cluster is replicating:**
+   ```bash
+   kubectl cnpg status database-cnpg -n mastodon
+   kubectl get pods -n mastodon -l cnpg.io/cluster=database-cnpg
+   ```
+
+3. **Monitor replication lag:**
+   ```bash
+   kubectl cnpg psql database-cnpg -n mastodon -- \
+     -c "SELECT pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn());"
+   ```
+   The result should be less than 1KB before the cutover window starts.
+
+## Cutover Steps (Planned Maintenance Window)
+
+1. **Scale down all Mastodon workloads:**
+   ```bash
+   kubectl scale deployment -n mastodon \
+     mastodon-web \
+     mastodon-streaming \
+     mastodon-sidekiq-default \
+     mastodon-sidekiq-federation \
+     mastodon-sidekiq-background \
+     mastodon-sidekiq-scheduler \
+     --replicas=0
+   ```
+
+2. **Wait for replication lag to reach 0 bytes.**
+
+3. **Promote the CNPG cluster:**
+   ```bash
+   kubectl apply -f kubernetes/apps/platform/mastodon/resources/workloads/database-cnpg-promoted.yaml
+   ```
+
+4. **Fetch the new application credentials:**
+   ```bash
+   kubectl get secret database-cnpg-app -n mastodon \
+     -o jsonpath='{.data.password}' | base64 -d
+   ```
+
+5. **Update the Mastodon database URL secret:**
+   ```bash
+   kubectl create secret generic mastodon-db-url -n mastodon \
+     --from-literal=DATABASE_URL="postgresql://mastodon:<password>@database-cnpg-pooler-rw-rw.mastodon.svc.cluster.local:5432/mastodon?sslmode=verify-ca" \
+     --dry-run=client -o yaml | kubectl apply -f -
+   ```
+
+6. **Update the ConfigMap with the new host:**
+   ```bash
+   kubectl patch configmap mastodon-database -n mastodon --type merge -p '{
+     "data":{
+       "DB_HOST":"database-cnpg-pooler-rw-rw.mastodon.svc.cluster.local",
+       "DB_PORT":"5432"
+     }
+   }'
+   ```
+
+7. **Refresh the collation version:**
+   ```bash
+   kubectl cnpg psql database-cnpg -n mastodon -- \
+     -c "ALTER DATABASE mastodon REFRESH COLLATION VERSION;"
+   ```
+
+8. **Bring the Mastodon workloads back online:**
+   ```bash
+   kubectl scale deployment -n mastodon \
+     mastodon-web --replicas=1 \
+     mastodon-streaming --replicas=1 \
+     mastodon-sidekiq-default --replicas=1 \
+     mastodon-sidekiq-federation --replicas=1 \
+     mastodon-sidekiq-background --replicas=1 \
+     mastodon-sidekiq-scheduler --replicas=1
+   ```
+
+9. **Confirm the application is healthy:**
+   ```bash
+   kubectl get pods -n mastodon
+   kubectl logs -n mastodon -l app=mastodon-web --tail=50
+   ```
+
+## Post-Cutover (After 48 Hours of Stable Operation)
+
+1. **Remove the Zalando manifest from Git:**
+   Edit `kubernetes/apps/platform/mastodon/resources/workloads/kustomization.yaml` and delete the `- database.yaml` entry.
+
+2. **Replace the replica manifest:**
+   ```bash
+   mv kubernetes/apps/platform/mastodon/resources/workloads/database-cnpg-promoted.yaml \
+     kubernetes/apps/platform/mastodon/resources/workloads/database-cnpg.yaml
+   ```
+
+3. **Optionally scale down the Zalando operator:**
+   ```bash
+   kubectl scale deployment zalando-postgres-operator -n postgres-operator --replicas=0
+   ```

--- a/kubernetes/apps/platform/mastodon/resources/workloads/database-cnpg-promoted.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/workloads/database-cnpg-promoted.yaml
@@ -1,0 +1,121 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: database-cnpg
+  namespace: mastodon
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
+  primaryUpdateStrategy: unsupervised
+  enablePDB: true
+  env:
+    - name: AWS_REQUEST_CHECKSUM_CALCULATION
+      value: when_required
+    - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+      value: when_required
+    - name: AWS_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          name: mastodon-walg-s3
+          key: AWS_ACCESS_KEY_ID
+    - name: AWS_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: mastodon-walg-s3
+          key: AWS_SECRET_ACCESS_KEY
+    - name: AWS_ENDPOINT
+      valueFrom:
+        secretKeyRef:
+          name: mastodon-walg-s3
+          key: AWS_ENDPOINT
+    - name: WAL_S3_BUCKET
+      valueFrom:
+        secretKeyRef:
+          name: mastodon-walg-s3
+          key: WAL_S3_BUCKET
+  storage:
+    size: 40Gi
+  walStorage:
+    size: 10Gi
+  monitoring:
+    enablePodMonitor: true
+  postgresql:
+    parameters:
+      max_connections: "300"
+      shared_buffers: "512MB"
+      effective_cache_size: "512MB"
+      maintenance_work_mem: "128MB"
+      checkpoint_completion_target: "0.9"
+      wal_buffers: "16MB"
+      default_statistics_target: "100"
+      random_page_cost: "1.1"
+      effective_io_concurrency: "100"
+      work_mem: "1702kB"
+      huge_pages: "off"
+      min_wal_size: "2GB"
+      max_wal_size: "8GB"
+      max_worker_processes: "4"
+      max_parallel_workers_per_gather: "2"
+      max_parallel_workers: "4"
+      max_parallel_maintenance_workers: "2"
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: "all"
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: database-backup
+  resources:
+    requests:
+      memory: "2Gi"
+      cpu: "1"
+    limits:
+      memory: "2Gi"
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname
+  tolerations:
+    - key: "autoscaler-node"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: database-cnpg-backup
+  namespace: mastodon
+spec:
+  schedule: "0 0 6 * * 1,4"
+  backupOwnerReference: self
+  cluster:
+    name: database-cnpg
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: database-backup
+  namespace: mastodon
+spec:
+  configuration:
+    destinationPath: s3://mastovault/cnpg/mastodon-database
+    endpointURL: https://s3.jorijn.com
+    s3Credentials:
+      accessKeyId:
+        name: mastodon-walg-s3
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: mastodon-walg-s3
+        key: AWS_SECRET_ACCESS_KEY
+    wal:
+      compression: gzip
+    data:
+      additionalCommandArgs:
+        - --max-archive-size=10GB
+        - --min-chunk-size=64MB
+        - --read-timeout=180
+  retentionPolicy: "14d"

--- a/kubernetes/apps/platform/mastodon/resources/workloads/database-cnpg.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/workloads/database-cnpg.yaml
@@ -1,0 +1,158 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: zalando-standby-credentials
+  namespace: mastodon
+type: kubernetes.io/basic-auth
+stringData:
+  username: standby
+  password: ""
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: database-cnpg
+  namespace: mastodon
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
+  bootstrap:
+    pg_basebackup:
+      source: zalando-cluster
+  replica:
+    enabled: true
+    source: zalando-cluster
+  storage:
+    size: 40Gi
+  walStorage:
+    size: 10Gi
+  monitoring:
+    enablePodMonitor: true
+  postgresql:
+    parameters:
+      max_connections: "300"
+      shared_buffers: "512MB"
+      effective_cache_size: "512MB"
+      maintenance_work_mem: "128MB"
+      checkpoint_completion_target: "0.9"
+      wal_buffers: "16MB"
+      default_statistics_target: "100"
+      random_page_cost: "1.1"
+      effective_io_concurrency: "100"
+      work_mem: "1702kB"
+      huge_pages: "off"
+      min_wal_size: "2GB"
+      max_wal_size: "8GB"
+      max_worker_processes: "4"
+      max_parallel_workers_per_gather: "2"
+      max_parallel_workers: "4"
+      max_parallel_maintenance_workers: "2"
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: "all"
+  externalClusters:
+    - name: zalando-cluster
+      connectionParameters:
+        host: mastodon-postgresql.mastodon.svc.cluster.local
+        port: "5432"
+        user: standby
+        dbname: postgres
+        sslmode: verify-ca
+      password:
+        name: zalando-standby-credentials
+        key: password
+      sslRootCert:
+        name: mastodon-postgresql-ca
+        key: ca.crt
+  resources:
+    requests:
+      memory: "2Gi"
+      cpu: "1"
+    limits:
+      memory: "2Gi"
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname
+  tolerations:
+    - key: "autoscaler-node"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: database-cnpg-pooler-rw
+  namespace: mastodon
+spec:
+  cluster:
+    name: database-cnpg
+  instances: 2
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "1000"
+      default_pool_size: "125"
+  template:
+    metadata:
+      labels:
+        app: database-cnpg-pooler-rw
+    spec:
+      containers:
+        - resources:
+            requests:
+              cpu: 10m
+              memory: 100Mi
+            limits:
+              memory: 100Mi
+          name: pgbouncer
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - database-cnpg-pooler-rw
+              topologyKey: "kubernetes.io/hostname"
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: database-cnpg-pooler-ro
+  namespace: mastodon
+spec:
+  cluster:
+    name: database-cnpg
+  instances: 2
+  type: ro
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "1000"
+      default_pool_size: "125"
+  template:
+    metadata:
+      labels:
+        app: database-cnpg-pooler-ro
+    spec:
+      containers:
+        - resources:
+            requests:
+              cpu: 10m
+              memory: 100Mi
+            limits:
+              memory: 100Mi
+          name: pgbouncer
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - database-cnpg-pooler-ro
+              topologyKey: "kubernetes.io/hostname"

--- a/kubernetes/apps/platform/mastodon/resources/workloads/kustomization.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/workloads/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - database.yaml
+- database-cnpg.yaml
 - elastic-sts.yaml
 - redis-statefulset.yaml
 - sidekiq-default-deployment.yaml


### PR DESCRIPTION
## Summary
- add the CloudNativePG replica cluster, poolers, and supporting manifests for Mastodon
- register the new CloudNativePG operator in the database kustomization and document the promotion plan

## Testing
- `kustomize build kubernetes/apps/platform/mastodon/resources/workloads`
- `kustomize build --enable-helm kubernetes/apps/database` *(fails: helm repository blocked by proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e236ff13f88322b16df85c655c7724