### PR TITLE
Fix mastodon sidekiq background queue registration

### DIFF
--- a/kubernetes/apps/platform/mastodon/resources/workloads/sidekiq-background-deployment.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/workloads/sidekiq-background-deployment.yaml
@@ -37,6 +37,7 @@ spec:
             - pull
             - -q
             - mailers
+            - -q
             - fasp
             - -c
             - "10"


### PR DESCRIPTION
## Summary
- register the fasp queue in the background Sidekiq deployment so Mastodon detects it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8d744ffd883229077611041ef63f1