### PR TITLE
fix: Resolve Tor hidden service DNS and networking issues

### DIFF
--- a/kubernetes/apps/platform/mastodon/resources/networking/kustomization.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/networking/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
 - elastic-networkpolicy.yaml
 - http-route.yaml
 - httproute-es.yaml
+- mastodon-onion-networkpolicy.yaml
 - redis-NetworkPolicy.yaml

--- a/kubernetes/apps/platform/mastodon/resources/networking/mastodon-onion-networkpolicy.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/networking/mastodon-onion-networkpolicy.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mastodon-onion
+  namespace: mastodon
+spec:
+  podSelector:
+    matchLabels:
+      app: mastodon-onion
+  policyTypes:
+  - Egress
+  - Ingress
+  # No ingress needed - traffic comes from Tor network, not K8s
+  ingress: []
+  egress:
+  # Allow all egress (Tor needs to connect to Tor network and backend services)
+  - {}

--- a/kubernetes/apps/platform/mastodon/resources/services/kustomization.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/services/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - elastic-svc.yaml
+- mastodon-onion-svc.yaml
 - redis-svc.yaml
 - svc-streaming.yaml
 - web-svc.yaml

--- a/kubernetes/apps/platform/mastodon/resources/services/mastodon-onion-svc.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/services/mastodon-onion-svc.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mastodon-onion
+  namespace: mastodon
+  labels:
+    app: mastodon-onion
+    component: tor-hidden-service
+spec:
+  type: ClusterIP
+  selector:
+    app: mastodon-onion
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+    - name: streaming
+      port: 4000
+      targetPort: 4000

--- a/kubernetes/apps/platform/mastodon/resources/workloads/tor-onion-torrc.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/workloads/tor-onion-torrc.yaml
@@ -9,7 +9,15 @@ data:
     Log notice stdout
     Log info file /var/lib/tor/notice.log
     DataDirectory /var/lib/tor
+
+    # Hidden Service Configuration
     HiddenServiceDir /var/lib/tor/hidden_service
     HiddenServiceVersion 3
-    HiddenServicePort 80 mastodon-web.mastodon.svc.cluster.local:3000
-    HiddenServicePort 4000 mastodon-streaming.mastodon.svc.cluster.local:4000
+    HiddenServicePort 80 mastodon-web:3000
+    HiddenServicePort 4000 mastodon-streaming:4000
+
+    # DNS and connectivity settings for Kubernetes
+    # Allow Tor to use system DNS resolver for backend services
+    ServerDNSResolvConfFile /etc/resolv.conf
+    # Test reachability settings
+    AssumeReachable 1


### PR DESCRIPTION
## Summary

This PR fixes the Tor hidden service integration that was preventing the .onion site from being reachable through Tor Browser.

### Root Cause
The torrc configuration was using fully qualified Kubernetes DNS names (mastodon-web.mastodon.svc.cluster.local) which Tor could not properly resolve, preventing the hidden service descriptor from being published.

### Changes
- Updated torrc to use short service names with proper DNS configuration
- Added ServerDNSResolvConfFile and AssumeReachable directives
- Created Service resource for observability
- Created NetworkPolicy with proper egress rules
- Updated kustomization files

### Testing
After deployment, verify:
1. Tor logs show hidden service activity
2. Descriptor is published to Tor network
3. .onion site is reachable via Tor Browser (HTTP)

Fixes #91

---
🤖 Generated with [Claude Code](https://claude.ai/code)