### PR TITLE
fix(elasticsearch): set secure permissions for password file

### DIFF
--- a/kubernetes/apps/platform/mastodon/resources/workloads/elastic-sts.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/workloads/elastic-sts.yaml
@@ -152,6 +152,7 @@ spec:
         emptyDir: {}
       - name: elasticsearch-secrets
         projected:
+          defaultMode: 256
           sources:
           - secret:
               name: elasticsearch-credentials


### PR DESCRIPTION
Set defaultMode to 256 (0400 octal) for elasticsearch-secrets volume to ensure
the password file has owner-read-only permissions. Elasticsearch requires strict
permissions (0400 or 0600) on credential files and will refuse to start with
the default Kubernetes secret permissions of 0644.

Fixes #99

Generated with [Claude Code](https://claude.ai/code)