### PR TITLE
fix(elasticsearch): remove fsGroup to allow 0400 file permissions

### DIFF
--- a/kubernetes/apps/platform/mastodon/resources/workloads/elastic-sts.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/workloads/elastic-sts.yaml
@@ -142,8 +142,6 @@ spec:
           privileged: true
           runAsUser: 0
       securityContext:
-        fsGroup: 1000
-        fsGroupChangePolicy: Always
         supplementalGroups: []
         sysctls: []
       serviceAccountName: elasticsearch-master


### PR DESCRIPTION
The fsGroup setting was causing Kubernetes to add group-read permissions to secret files, resulting in 0440 permissions instead of the required 0400. Elasticsearch refuses to start with password files that have group or world permissions.

Removing fsGroup allows the defaultMode: 256 (0400) to work correctly. The container already runs as UID 1000 (runAsUser) and GID 1000 (runAsGroup), so file ownership will be correct without fsGroup.

Fixes #99

Generated with [Claude Code](https://claude.ai/code)