### PR TITLE
fix(mastodon): add ALTERNATE_DOMAINS for Tor onion service

### DIFF
--- a/kubernetes/apps/platform/mastodon/configs/mastodon-core.env
+++ b/kubernetes/apps/platform/mastodon/configs/mastodon-core.env
@@ -12,7 +12,9 @@ MASTODON_PROMETHEUS_EXPORTER_ENABLED=true
 MASTODON_PROMETHEUS_EXPORTER_LOCAL=false
 MASTODON_PROMETHEUS_EXPORTER_PORT=9394
 
+# Onion service configuration
 ALLOW_ACCESS_TO_HIDDEN_SERVICE=true
+ALTERNATE_DOMAINS=eopvgbrhvri7tj2gbvssa3zpgxzm6rbwf6ozmk33elox3kce3zo75gid.onion
 http_proxy=http://tor-proxy.mastodon.svc.cluster.local:8118
 http_hidden_proxy=http://tor-proxy.mastodon.svc.cluster.local:8118
 NO_PROXY=localhost,127.0.0.1,.svc,.cluster.local,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16


### PR DESCRIPTION
## Summary

Fixed the Tor onion service showing an empty page by adding the `ALTERNATE_DOMAINS` environment variable to Mastodon's configuration.

## Changes

- Added `ALTERNATE_DOMAINS=eopvgbrhvri7tj2gbvssa3zpgxzm6rbwf6ozmk33elox3kce3zo75gid.onion` to `kubernetes/apps/platform/mastodon/configs/mastodon-core.env`
- This tells Mastodon to accept HTTP requests with the .onion hostname in addition to the main domain

## Testing

After merge and ArgoCD sync:
1. Mastodon pods will restart with the new configuration
2. Access the onion service at `http://eopvgbrhvri7tj2gbvssa3zpgxzm6rbwf6ozmk33elox3kce3zo75gid.onion`
3. Mastodon should now load properly instead of showing an empty page

Fixes #101

---

Generated with [Claude Code](https://claude.ai/code)