### PR TITLE
fix(mastodon): resolve Elasticsearch container crash due to secret file permissions

### DIFF
--- a/kubernetes/apps/platform/mastodon/resources/workloads/elastic-sts.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/workloads/elastic-sts.yaml
@@ -107,12 +107,50 @@ spec:
           subPath: app-logs-dir
         - name: data
           mountPath: /usr/share/elasticsearch/data
-        - name: elasticsearch-secrets
+        - name: elasticsearch-secrets-writable
           mountPath: /usr/share/elasticsearch/config/secrets
         - name: elasticsearch-certificates
           mountPath: /usr/share/elasticsearch/config/certs
           readOnly: true
       initContainers:
+      - name: fix-secret-permissions
+        image: ubuntu:24.04
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/bash
+        - -ec
+        - |
+          # Copy secrets from read-only projected volume to writable emptyDir
+          # and set correct permissions (0400) required by Elasticsearch
+          cp /secrets-ro/elasticsearch-password /secrets-rw/elasticsearch-password
+          chmod 0400 /secrets-rw/elasticsearch-password
+          echo "Fixed secret permissions: $(stat -c '%a' /secrets-rw/elasticsearch-password)"
+        volumeMounts:
+        - name: elasticsearch-secrets
+          mountPath: /secrets-ro
+          readOnly: true
+        - name: elasticsearch-secrets-writable
+          mountPath: /secrets-rw
+        resources:
+          requests:
+            cpu: 50m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+            ephemeral-storage: 10Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          seccompProfile:
+            type: RuntimeDefault
       - name: sysctl
         image: ubuntu:24.04
         imagePullPolicy: IfNotPresent
@@ -154,6 +192,8 @@ spec:
           sources:
           - secret:
               name: elasticsearch-credentials
+      - name: elasticsearch-secrets-writable
+        emptyDir: {}
       - name: elasticsearch-certificates
         secret:
           defaultMode: 256


### PR DESCRIPTION
Fixes #104

Elasticsearch 9.1.5 requires password files to have exactly 0400 or 0600 permissions. However, Kubernetes projected secret volumes can result in 0440 permissions due to kubelet's atomic writer behavior, causing the container to crash on startup.

This PR adds a fix-secret-permissions init container that:
- Copies the secret from the read-only projected volume to a writable emptyDir
- Sets the correct 0400 permissions required by Elasticsearch
- Runs as the same non-root user (UID 1000) as the main container

This is a standard workaround for the Kubernetes limitation where projected volumes cannot guarantee exact file permissions, especially when group read bits are added by the kubelet.

Generated with [Claude Code](https://claude.ai/code)