### PR TITLE
fix: Enable CNPG S3 backups by using database-cnpg-promoted.yaml

### DIFF
--- a/kubernetes/apps/platform/mastodon/resources/workloads/kustomization.yaml
+++ b/kubernetes/apps/platform/mastodon/resources/workloads/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- database-cnpg.yaml
+- database-cnpg-promoted.yaml
 - elastic-sts.yaml
 - redis-statefulset.yaml
 - sidekiq-default-deployment.yaml


### PR DESCRIPTION
## Summary

Fixed S3 backups for CloudNative-PG after migration from Zalando postgres-operator.

## Changes

- Switched from `database-cnpg.yaml` to `database-cnpg-promoted.yaml` in kustomization
- This enables ScheduledBackup resource (6am Mon & Thu)
- Configures ObjectStore for S3 (s3://mastovault/cnpg/mastodon-database)
- Enables Barman Cloud plugin for continuous WAL archiving
- S3 credentials via existing mastodon-walg-s3 secret (verified correct)

Fixes #108

🤖 Generated with [Claude Code](https://claude.ai/code)